### PR TITLE
feat: use medusa catalog for product pages

### DIFF
--- a/apps/next/app/[locale]/(marketing)/products/page.tsx
+++ b/apps/next/app/[locale]/(marketing)/products/page.tsx
@@ -10,6 +10,7 @@ import { Subheading } from '@/components/elements/subheading';
 import { Featured } from '@/components/products/featured';
 import { ProductItems } from '@/components/products/product-items';
 import fetchContentType from '@/lib/cms/fetchContentType';
+import { fetchMedusaProducts } from '@/lib/medusa/products';
 import { generateMetadataObject } from '@/lib/shared/metadata';
 
 export async function generateMetadata(props: {
@@ -47,7 +48,7 @@ export default async function Products(props: {
     },
     true
   );
-  const products = await fetchContentType('products');
+  const products = await fetchMedusaProducts();
 
   const localizedSlugs = productPage.localizations?.reduce(
     (acc: Record<string, string>, localization: any) => {
@@ -56,9 +57,7 @@ export default async function Products(props: {
     },
     { [params.locale]: 'products' }
   );
-  const featured = products?.data.filter(
-    (product: { featured: boolean }) => product.featured
-  );
+  const featured = products.slice(0, 3);
 
   return (
     <div className="relative overflow-hidden w-full">
@@ -75,7 +74,7 @@ export default async function Products(props: {
           {productPage.sub_heading}
         </Subheading>
         <Featured products={featured} locale={params.locale} />
-        <ProductItems products={products?.data} locale={params.locale} />
+        <ProductItems products={products} locale={params.locale} />
       </Container>
     </div>
   );

--- a/apps/next/components/products/featured.tsx
+++ b/apps/next/components/products/featured.tsx
@@ -12,6 +12,12 @@ export const Featured = ({
   products: Product[];
   locale: string;
 }) => {
+  if (!products?.length) {
+    return null;
+  }
+
+  const [first, second, third] = products.slice(0, 3);
+
   return (
     <div className="py-20">
       <h2 className="text-2xl md:text-4xl font-medium bg-clip-text text-transparent bg-gradient-to-b from-neutral-800 via-white to-white mb-2">
@@ -21,12 +27,14 @@ export const Featured = ({
         Pick from our most popular collection
       </p>
       <div className="grid grid-cols-1 md:grid-cols-3  gap-10">
-        <div className="md:col-span-2">
-          <FeaturedItem product={products[0]} locale={locale} />
-        </div>
+        {first && (
+          <div className="md:col-span-2">
+            <FeaturedItem product={first} locale={locale} />
+          </div>
+        )}
         <div className="grid gap-10">
-          <FeaturedItem product={products[1]} locale={locale} />
-          <FeaturedItem product={products[2]} locale={locale} />
+          {second && <FeaturedItem product={second} locale={locale} />}
+          {third && <FeaturedItem product={third} locale={locale} />}
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-10"></div>
@@ -41,6 +49,8 @@ const FeaturedItem = ({
   product: Product;
   locale: string;
 }) => {
+  const currencySymbol =
+    product.currency_code?.toUpperCase() === 'EUR' ? '€' : '$';
   return (
     <Link
       href={`/${locale}/products/${product.slug}` as never}
@@ -50,7 +60,8 @@ const FeaturedItem = ({
       <div className="absolute text-sm top-4 right-2 md:top-10 md:right-10 z-40 bg-white rounded-full pr-1 pl-4 py-1 text-black font-medium flex gap-4 items-center">
         <span>{product.name}</span>
         <span className="bg-gradient-to-r from-purple-500 via-indigo-500 to-blue-500 text-white px-2 py-1 rounded-full">
-          ${formatNumber(product.price)}
+          {currencySymbol}
+          {formatNumber(product.price)}
         </span>
       </div>
       <MediaImage

--- a/apps/next/components/products/modal.tsx
+++ b/apps/next/components/products/modal.tsx
@@ -13,9 +13,15 @@ import {
 import { MediaImage } from '@/components/ui/media-image';
 import { useCart } from '@/context/cart-context';
 import { formatNumber } from '@/lib/utils';
+import { Product } from '@/types/types';
 
 export default function AddToCartModal({ onClick }: { onClick: () => void }) {
   const { items, updateQuantity, getCartTotal, removeFromCart } = useCart();
+  const currencySymbolFor = (product: Product) =>
+    product.currency_code?.toUpperCase() === 'EUR' ? '€' : '$';
+  const totalCurrencySymbol = items[0]
+    ? currencySymbolFor(items[0].product)
+    : '$';
   return (
     <Modal>
       <ModalTrigger onClick={onClick} className="mt-10 w-full">
@@ -70,7 +76,8 @@ export default function AddToCartModal({ onClick }: { onClick: () => void }) {
                     }}
                   />
                   <div className="text-black text-sm font-medium w-20">
-                    ${formatNumber(item.product.price)}
+                    {currencySymbolFor(item.product)}
+                    {formatNumber(item.product.price)}
                   </div>
                   <button onClick={() => removeFromCart(item.product.id)}>
                     <IconTrash className="w-4 h-4 text-neutral-900" />
@@ -83,7 +90,10 @@ export default function AddToCartModal({ onClick }: { onClick: () => void }) {
         <ModalFooter className="gap-4 items-center">
           <div className="text-neutral-700 ">
             total amount{' '}
-            <span className="font-bold">${formatNumber(getCartTotal())}</span>
+            <span className="font-bold">
+              {totalCurrencySymbol}
+              {formatNumber(getCartTotal())}
+            </span>
           </div>
           <button
             disabled={!items.length}

--- a/apps/next/components/products/product-items.tsx
+++ b/apps/next/components/products/product-items.tsx
@@ -42,6 +42,8 @@ const ProductItem = ({
   product: Product;
   locale: string;
 }) => {
+  const currencySymbol =
+    product.currency_code?.toUpperCase() === 'EUR' ? '€' : '$';
   return (
     <Link
       href={`/${locale}/products/${product.slug}` as never}
@@ -65,7 +67,8 @@ const ProductItem = ({
             {product.name}
           </span>
           <span className="bg-white text-black shadow-derek text-xs px-2 py-1 rounded-full">
-            ${formatNumber(product.price)}
+            {currencySymbol}
+            {formatNumber(product.price)}
           </span>
         </div>
         <p className="text-neutral-400 text-sm mt-4">

--- a/apps/next/components/products/single-product.tsx
+++ b/apps/next/components/products/single-product.tsx
@@ -12,10 +12,13 @@ import { cn, formatNumber } from '@/lib/utils';
 import { Product } from '@/types/types';
 
 export const SingleProduct = ({ product }: { product: Product }) => {
-  const [activeThumbnail, setActiveThumbnail] = useState(
-    resolveMediaUrl(product.images[0].url)
+  const initialImage = product.images?.[0]?.url ?? null;
+  const [activeThumbnail, setActiveThumbnail] = useState<string | null>(
+    initialImage ? resolveMediaUrl(initialImage) : null
   );
   const { addToCart } = useCart();
+  const currencySymbol =
+    product.currency_code?.toUpperCase() === 'EUR' ? '€' : '$';
 
   return (
     <div className="bg-gradient-to-b from-neutral-900 to-neutral-950  p-4 md:p-10 rounded-md">
@@ -39,37 +42,42 @@ export const SingleProduct = ({ product }: { product: Product }) => {
               alt={product.name}
               width={600}
               height={600}
-              // fill
               className="rounded-lg object-cover"
             />
           </motion.div>
           {/* </AnimatePresence> */}
           <div className="flex gap-4 justify-center items-center mt-4">
-            {product.images &&
-              product.images.map((image, index) => (
+            {product.images?.map((image, index) => {
+              if (!image?.url) {
+                return null;
+              }
+              const resolvedUrl = resolveMediaUrl(image.url);
+              return (
                 <button
-                  onClick={() => setActiveThumbnail(resolveMediaUrl(image.url))}
-                  key={'product-image' + index}
+                  onClick={() => setActiveThumbnail(resolvedUrl)}
+                  key={`product-image-${index}`}
                   className={cn(
                     'h-20 w-20 rounded-xl',
-                    activeThumbnail === resolveMediaUrl(image.url)
+                    activeThumbnail === resolvedUrl
                       ? 'border-2 border-neutral-200'
                       : 'border-2 border-transparent'
                   )}
                   style={{
-                    backgroundImage: `url(${resolveMediaUrl(image.url)})`,
+                    backgroundImage: `url(${resolvedUrl})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
                   }}
                 ></button>
-              ))}
+              );
+            })}
           </div>
         </div>
         <div>
           <h2 className="text-2xl font-semibold mb-4">{product.name}</h2>
           <p className=" mb-6 bg-white text-xs px-4 py-1 rounded-full text-black w-fit">
-            ${formatNumber(product.price)}
+            {currencySymbol}
+            {formatNumber(product.price)}
           </p>
           <p className="text-base font-normal mb-4 text-neutral-400">
             {product.description}

--- a/apps/next/context/cart-context.tsx
+++ b/apps/next/context/cart-context.tsx
@@ -13,7 +13,7 @@ type CartContextType = {
   items: CartItem[];
   updateQuantity: (product: Product, quantity: number) => void;
   addToCart: (product: Product) => void;
-  removeFromCart: (productId: number) => void;
+  removeFromCart: (productId: string) => void;
   clearCart: () => void;
   getCartTotal: () => number;
 };
@@ -41,7 +41,7 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }, []);
 
-  const removeFromCart = useCallback((productId: number) => {
+  const removeFromCart = useCallback((productId: string) => {
     setItems((prevItems) =>
       prevItems.filter((item) => item.product.id !== productId)
     );

--- a/apps/next/lib/medusa/products.ts
+++ b/apps/next/lib/medusa/products.ts
@@ -1,0 +1,221 @@
+import qs from 'qs';
+
+import { Product } from '@/types/types';
+
+interface MedusaPrice {
+  amount: number;
+  currency_code: string;
+}
+
+interface MedusaProductOptionValue {
+  id: string;
+  value: string;
+}
+
+interface MedusaProductOption {
+  id: string;
+  title: string;
+  values?: MedusaProductOptionValue[];
+}
+
+interface MedusaProductVariant {
+  id: string;
+  title: string;
+  prices?: MedusaPrice[];
+}
+
+interface MedusaProductCategory {
+  id: string;
+  name: string;
+}
+
+interface MedusaProductImage {
+  id?: string;
+  url: string;
+}
+
+interface MedusaProduct {
+  id: string;
+  title: string;
+  handle: string;
+  description?: string;
+  thumbnail?: string;
+  images?: MedusaProductImage[];
+  variants?: MedusaProductVariant[];
+  options?: MedusaProductOption[];
+  categories?: MedusaProductCategory[];
+  collections?: { id: string; title: string }[];
+}
+
+interface MedusaListResponse<T> {
+  products: T[];
+}
+
+const DEFAULT_EXPAND = [
+  'variants',
+  'variants.prices',
+  'images',
+  'options',
+  'categories',
+  'collections',
+].join(',');
+
+const DEFAULT_LIMIT = 50;
+
+function getMedusaBaseUrl(): string {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_MEDUSA_URL ??
+    process.env.NEXT_PUBLIC_API_URL ??
+    'http://localhost:9000';
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+async function medusaFetch<T>(path: string): Promise<T | null> {
+  const baseUrl = getMedusaBaseUrl();
+
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+  try {
+    const response = await fetch(url, { cache: 'no-store' });
+    if (!response.ok) {
+      console.error(`Failed to fetch Medusa data from ${url}: ${response.status}`);
+      return null;
+    }
+    return (await response.json()) as T;
+  } catch (error) {
+    console.error('Failed to fetch Medusa data', error);
+    return null;
+  }
+}
+
+function normaliseAmount(amount: number): number {
+  if (amount >= 100) {
+    return amount / 100;
+  }
+  return amount;
+}
+
+function extractPrice(product: MedusaProduct, preferredCurrency = 'usd') {
+  const priceEntries =
+    product.variants?.flatMap((variant) => variant.prices ?? []) ?? [];
+  if (!priceEntries.length) {
+    return { amount: 0, currency_code: preferredCurrency };
+  }
+
+  const preferredPrices = priceEntries.filter(
+    (price) => price.currency_code.toLowerCase() === preferredCurrency
+  );
+  const relevantPrices = preferredPrices.length ? preferredPrices : priceEntries;
+
+  const minAmount = Math.min(...relevantPrices.map((price) => price.amount));
+  const currency_code = relevantPrices[0]?.currency_code ?? preferredCurrency;
+
+  return {
+    amount: normaliseAmount(minAmount),
+    currency_code,
+  };
+}
+
+function mapOptionToPerk(option: MedusaProductOption) {
+  const values = option.values ?? [];
+  const formattedValues = values
+    .map((value) => value.value)
+    .filter(Boolean)
+    .join(', ');
+
+  if (!formattedValues) {
+    return null;
+  }
+
+  return {
+    text: `${option.title}: ${formattedValues}`,
+  };
+}
+
+function mapMedusaProduct(product: MedusaProduct): Product {
+  const { amount, currency_code } = extractPrice(product);
+  const images = product.images?.length
+    ? product.images
+    : product.thumbnail
+    ? [{ url: product.thumbnail }]
+    : [];
+
+  const perks = (product.options ?? [])
+    .map(mapOptionToPerk)
+    .filter((perk): perk is { text: string } => Boolean(perk));
+
+  const plans = (product.variants ?? []).map((variant) => ({
+    id: variant.id,
+    name: variant.title,
+  }));
+
+  return {
+    id: product.id,
+    name: product.title,
+    slug: product.handle,
+    description: product.description ?? '',
+    price: amount,
+    currency_code,
+    plans,
+    perks,
+    featured: false,
+    images,
+    categories: product.categories ?? [],
+    collections: product.collections ?? [],
+    dynamic_zone: [],
+  };
+}
+
+export async function fetchMedusaProducts(): Promise<Product[]> {
+  const query = qs.stringify(
+    {
+      limit: DEFAULT_LIMIT,
+      expand: DEFAULT_EXPAND,
+    },
+    { addQueryPrefix: true }
+  );
+
+  const data = await medusaFetch<MedusaListResponse<MedusaProduct>>(
+    `/store/products${query}`
+  );
+
+  if (!data?.products?.length) {
+    return [];
+  }
+
+  return data.products.map(mapMedusaProduct);
+}
+
+export async function fetchMedusaProductByHandle(
+  handle: string
+): Promise<Product | null> {
+  const query = qs.stringify(
+    {
+      handle,
+      limit: 1,
+      expand: DEFAULT_EXPAND,
+    },
+    { addQueryPrefix: true }
+  );
+
+  const data = await medusaFetch<MedusaListResponse<MedusaProduct>>(
+    `/store/products${query}`
+  );
+
+  if (!data?.products?.length) {
+    return null;
+  }
+
+  return mapMedusaProduct(data.products[0]);
+}
+
+export async function fetchMedusaCollections() {
+  const data = await medusaFetch<{
+    collections: { id: string; title: string; handle: string }[];
+  }>(`/store/collections`);
+
+  if (!data?.collections?.length) {
+    return [];
+  }
+
+  return data.collections;
+}

--- a/apps/next/types/types.ts
+++ b/apps/next/types/types.ts
@@ -21,15 +21,43 @@ export interface Article {
   categories: Category[];
 }
 
+export interface ProductPlan {
+  id?: string;
+  name: string;
+}
+
+export interface ProductPerk {
+  text: string;
+}
+
+export interface ProductImage {
+  url: string;
+  alternativeText?: string | null;
+}
+
+export interface ProductCategory {
+  id?: string;
+  name: string;
+}
+
+export interface ProductCollection {
+  id?: string;
+  title: string;
+  handle?: string;
+}
+
 export interface Product {
-  id: number;
+  id: string;
   name: string;
   slug: string;
   description: string;
   price: number;
-  plans: any[];
-  perks: any[];
+  currency_code?: string;
+  plans: ProductPlan[];
+  perks: ProductPerk[];
   featured?: boolean;
-  images: any[];
-  categories?: any[];
+  images: ProductImage[];
+  categories?: ProductCategory[];
+  collections?: ProductCollection[];
+  dynamic_zone?: any[];
 }


### PR DESCRIPTION
## Summary
- add Medusa helpers to fetch products and collections from the store API
- render Medusa data on the product listing and detail pages, including currency-aware prices
- align cart, featured, and item components with the updated product model

## Testing
- yarn lint *(fails: Couldn't find the node_modules state file - running an install might help)*

------
https://chatgpt.com/codex/tasks/task_e_68d659af2cac83239247ef4bebf39b51