### PR TITLE
feat: connect cart and checkout to medusa

### DIFF
--- a/apps/next/components/products/modal.tsx
+++ b/apps/next/components/products/modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { IconTrash } from '@tabler/icons-react';
+import { IconCircleCheck, IconTrash } from '@tabler/icons-react';
 import React from 'react';
 
 import {
@@ -13,96 +13,257 @@ import {
 import { MediaImage } from '@/components/ui/media-image';
 import { useCart } from '@/context/cart-context';
 import { formatNumber } from '@/lib/utils';
-import { Product } from '@/types/types';
 
-export default function AddToCartModal({ onClick }: { onClick: () => void }) {
-  const { items, updateQuantity, getCartTotal, removeFromCart } = useCart();
-  const currencySymbolFor = (product: Product) =>
-    product.currency_code?.toUpperCase() === 'EUR' ? '€' : '$';
-  const totalCurrencySymbol = items[0]
-    ? currencySymbolFor(items[0].product)
-    : '$';
+export default function AddToCartModal({
+  onClick,
+}: {
+  onClick: () => void;
+}) {
+  const {
+    items,
+    currencyCode,
+    subtotal,
+    total,
+    updateQuantity,
+    removeFromCart,
+    checkout,
+    lastOrder,
+    error,
+    isLoading,
+    isUpdating,
+    isProcessingCheckout,
+  } = useCart();
+
+  const currencySymbol = currencyCode?.toUpperCase() === 'EUR' ? '€' : '$';
+
+  const handleQuantityChange = (lineItemId: string, value: number) => {
+    if (Number.isNaN(value) || value < 0) {
+      return;
+    }
+    void updateQuantity(lineItemId, value);
+  };
+
+  const handleRemove = (lineItemId: string) => {
+    void removeFromCart(lineItemId);
+  };
+
+  const handleCheckout = () => {
+    void checkout();
+  };
+
   return (
     <Modal>
-      <ModalTrigger onClick={onClick} className="mt-10 w-full">
-        Add to cart
+      <ModalTrigger
+        onClick={onClick}
+        disabled={isUpdating || isProcessingCheckout}
+        className="mt-10 w-full disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isUpdating ? 'Adding...' : 'Add to cart'}
       </ModalTrigger>
       <ModalBody>
         <ModalContent>
-          <h4 className="text-lg md:text-2xl text-neutral-600 font-bold text-center mb-8">
-            Your cart
+          <h4 className="text-lg md:text-2xl text-neutral-600 font-bold text-center mb-6">
+            {lastOrder ? 'Order confirmed' : 'Your cart'}
           </h4>
 
-          {!items.length && (
-            <p className="text-center text-neutral-700">
-              Your cart is empty. Please purchase something.
-            </p>
+          {error && (
+            <p className="text-center text-sm text-red-600 mb-4">{error}</p>
           )}
-          <div className="flex flex-col  divide-y divide-neutral-100">
-            {items.map((item, index) => (
-              <div
-                key={'purchased-item' + index}
-                className="flex gap-2 justify-between items-center py-4"
-              >
-                <div className="flex items-center gap-4">
-                  <MediaImage
-                    src={item.product?.images?.[0].url}
-                    alt={item.product.name}
-                    width={60}
-                    height={60}
-                    className="rounded-lg hidden md:block"
-                  />
-                  <span className="text-black text-sm md:text-base font-medium">
-                    {' '}
-                    {item.product.name}
-                  </span>
-                </div>
-                <div className="flex items-center">
-                  <input
-                    type="number"
-                    value={item.quantity}
-                    onChange={(e) => {
-                      const value = parseInt(e.target.value);
-                      if (value > 0) {
-                        updateQuantity(item.product, value);
-                      }
-                    }}
-                    min="1"
-                    step="1"
-                    className="w-16 p-2 h-full rounded-md focus:outline-none bg-neutral-50 border border-neutral-100 focus:bg-neutral-100 text-black mr-4"
-                    style={{
-                      WebkitAppearance: 'none',
-                      MozAppearance: 'textfield',
-                    }}
-                  />
-                  <div className="text-black text-sm font-medium w-20">
-                    {currencySymbolFor(item.product)}
-                    {formatNumber(item.product.price)}
-                  </div>
-                  <button onClick={() => removeFromCart(item.product.id)}>
-                    <IconTrash className="w-4 h-4 text-neutral-900" />
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
+
+          {lastOrder ? (
+            <OrderSummary currencySymbol={currencySymbol} order={lastOrder} />
+          ) : (
+            <CartItems
+              items={items}
+              isLoading={isLoading}
+              currencySymbol={currencySymbol}
+              onChangeQuantity={handleQuantityChange}
+              onRemoveItem={handleRemove}
+            />
+          )}
         </ModalContent>
-        <ModalFooter className="gap-4 items-center">
-          <div className="text-neutral-700 ">
-            total amount{' '}
-            <span className="font-bold">
-              {totalCurrencySymbol}
-              {formatNumber(getCartTotal())}
-            </span>
-          </div>
-          <button
-            disabled={!items.length}
-            className="bg-black text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm px-2 py-1 rounded-md border border-black w-28"
-          >
-            Buy now
-          </button>
-        </ModalFooter>
+        {!lastOrder && (
+          <ModalFooter className="gap-4 items-center">
+            <div className="text-neutral-700 flex-1">
+              <div className="text-xs uppercase text-neutral-500">Subtotal</div>
+              <div className="font-semibold text-sm">
+                {currencySymbol}
+                {formatNumber(subtotal)}
+              </div>
+            </div>
+            <div className="text-neutral-700 flex-1">
+              <div className="text-xs uppercase text-neutral-500">Total</div>
+              <div className="font-bold text-base">
+                {currencySymbol}
+                {formatNumber(total)}
+              </div>
+            </div>
+            <button
+              onClick={handleCheckout}
+              disabled={!items.length || isProcessingCheckout || isUpdating}
+              className="bg-black text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm px-3 py-2 rounded-md border border-black w-32"
+            >
+              {isProcessingCheckout ? 'Processing…' : 'Checkout'}
+            </button>
+          </ModalFooter>
+        )}
       </ModalBody>
     </Modal>
   );
 }
+
+type CartItemsProps = {
+  items: ReturnType<typeof useCart>['items'];
+  isLoading: boolean;
+  currencySymbol: string;
+  onChangeQuantity: (lineItemId: string, value: number) => void;
+  onRemoveItem: (lineItemId: string) => void;
+};
+
+const CartItems: React.FC<CartItemsProps> = ({
+  items,
+  isLoading,
+  currencySymbol,
+  onChangeQuantity,
+  onRemoveItem,
+}) => {
+  if (isLoading) {
+    return (
+      <p className="text-center text-neutral-500">Loading your cart…</p>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <p className="text-center text-neutral-700">
+        Your cart is empty. Please add a product to continue.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col divide-y divide-neutral-100">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="flex gap-2 justify-between items-center py-4"
+        >
+          <div className="flex items-center gap-4">
+            {item.thumbnail ? (
+              <MediaImage
+                src={item.thumbnail}
+                alt={item.title}
+                width={60}
+                height={60}
+                className="rounded-lg hidden md:block"
+              />
+            ) : (
+              <div className="hidden md:block h-[60px] w-[60px] rounded-lg bg-neutral-200" />
+            )}
+            <div className="flex flex-col">
+              <span className="text-black text-sm md:text-base font-medium">
+                {item.title}
+              </span>
+              <span className="text-neutral-500 text-xs">
+                {currencySymbol}
+                {formatNumber(item.unitPrice)} each
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center">
+            <input
+              type="number"
+              value={item.quantity}
+              onChange={(e) =>
+                onChangeQuantity(item.id, parseInt(e.target.value, 10))
+              }
+              min="1"
+              step="1"
+              className="w-16 p-2 h-full rounded-md focus:outline-none bg-neutral-50 border border-neutral-100 focus:bg-neutral-100 text-black mr-4"
+              style={{
+                WebkitAppearance: 'none',
+                MozAppearance: 'textfield',
+              }}
+            />
+            <div className="text-black text-sm font-medium w-20">
+              {currencySymbol}
+              {formatNumber(item.total)}
+            </div>
+            <button onClick={() => onRemoveItem(item.id)}>
+              <IconTrash className="w-4 h-4 text-neutral-900" />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+type OrderSummaryProps = {
+  order: ReturnType<typeof useCart>['lastOrder'];
+  currencySymbol: string;
+};
+
+const OrderSummary: React.FC<OrderSummaryProps> = ({ order, currencySymbol }) => {
+  if (!order) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-center gap-2 text-green-600">
+        <IconCircleCheck className="h-5 w-5" />
+        <span className="text-sm font-semibold">
+          Thank you! Your order #{order.displayId ?? order.id} is confirmed.
+        </span>
+      </div>
+      <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700">
+        <div className="flex justify-between">
+          <span className="font-medium">Total paid</span>
+          <span className="font-semibold text-neutral-900">
+            {currencySymbol}
+            {formatNumber(order.total)}
+          </span>
+        </div>
+        <div className="mt-3 space-y-2">
+          {order.items.map((item) => (
+            <div key={item.id} className="flex justify-between">
+              <span>
+                {item.title} × {item.quantity}
+              </span>
+              <span>
+                {currencySymbol}
+                {formatNumber(item.total)}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4">
+          <p className="text-xs text-neutral-500">
+            Status: {order.status ?? 'pending'} · Payment:{' '}
+            {order.paymentStatus ?? 'pending'} · Fulfilment:{' '}
+            {order.fulfillmentStatus ?? 'pending'}
+          </p>
+          {order.trackingLinks.length > 0 && (
+            <div className="mt-3 space-y-2">
+              <p className="text-xs font-medium text-neutral-600">
+                Tracking links
+              </p>
+              {order.trackingLinks.map((link) => (
+                <a
+                  key={`${link.url}-${link.trackingNumber ?? 'tracking'}`}
+                  href={link.url}
+                  className="text-xs text-blue-600 underline break-all"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {link.trackingNumber ?? link.url}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/next/components/ui/animated-modal.tsx
+++ b/apps/next/components/ui/animated-modal.tsx
@@ -46,19 +46,25 @@ export const ModalTrigger = ({
   children,
   className,
   onClick,
+  disabled,
 }: {
   children: ReactNode;
   className?: string;
   onClick?: () => void;
+  disabled?: boolean;
 }) => {
   const { setOpen } = useModal();
   return (
     <Button
       onClick={() => {
+        if (disabled) {
+          return;
+        }
         setOpen(true);
         onClick?.();
       }}
       className={className}
+      disabled={disabled}
     >
       {children}
     </Button>

--- a/apps/next/context/cart-context.tsx
+++ b/apps/next/context/cart-context.tsx
@@ -1,85 +1,456 @@
 'use client';
 
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
+import {
+  MedusaCart,
+  MedusaLineItem,
+  MedusaOrder,
+  addMedusaLineItem,
+  completeMedusaCart,
+  createMedusaCart,
+  deleteMedusaLineItem,
+  loadStoredCartId,
+  retrieveMedusaCart,
+  storeCartId,
+  updateMedusaLineItem,
+} from '@/lib/medusa/cart';
 import { Product } from '@/types/types';
 
+const DEFAULT_CURRENCY = 'usd';
+
 type CartItem = {
-  product: Product;
+  id: string;
+  title: string;
+  description?: string | null;
   quantity: number;
+  thumbnail?: string | null;
+  unitPrice: number;
+  total: number;
+  variantId: string;
+  productId: string;
+  currencyCode: string;
+};
+
+type TrackingLink = {
+  url: string;
+  trackingNumber?: string | null;
+};
+
+type OrderSummary = {
+  id: string;
+  displayId?: number;
+  status?: string;
+  paymentStatus?: string;
+  fulfillmentStatus?: string;
+  createdAt?: string;
+  currencyCode: string;
+  subtotal: number;
+  total: number;
+  items: CartItem[];
+  trackingLinks: TrackingLink[];
+};
+
+type NormalisedCart = {
+  id: string;
+  items: CartItem[];
+  currencyCode: string;
+  subtotal: number;
+  total: number;
 };
 
 type CartContextType = {
+  cartId: string | null;
   items: CartItem[];
-  updateQuantity: (product: Product, quantity: number) => void;
-  addToCart: (product: Product) => void;
-  removeFromCart: (productId: string) => void;
-  clearCart: () => void;
-  getCartTotal: () => number;
+  currencyCode: string;
+  subtotal: number;
+  total: number;
+  isLoading: boolean;
+  isUpdating: boolean;
+  isProcessingCheckout: boolean;
+  error: string | null;
+  lastOrder: OrderSummary | null;
+  addToCart: (product: Product, quantity?: number) => Promise<void>;
+  updateQuantity: (lineItemId: string, quantity: number) => Promise<void>;
+  removeFromCart: (lineItemId: string) => Promise<void>;
+  clearCart: () => Promise<void>;
+  checkout: () => Promise<OrderSummary | null>;
 };
 
 const CartContext = createContext<CartContextType | undefined>(undefined);
 
+function normaliseAmount(value?: number | null): number {
+  if (!value) {
+    return 0;
+  }
+  return value >= 100 ? value / 100 : value;
+}
+
+function mapLineItem(
+  item: MedusaLineItem,
+  currencyCode: string
+): CartItem {
+  const subtotal = item.total ?? item.subtotal ?? item.unit_price * item.quantity;
+
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description ?? undefined,
+    quantity: item.quantity,
+    thumbnail: item.thumbnail ?? undefined,
+    unitPrice: normaliseAmount(item.unit_price),
+    total: normaliseAmount(subtotal),
+    variantId: item.variant_id,
+    productId: item.product_id,
+    currencyCode,
+  };
+}
+
+function calculateItemsTotal(items: CartItem[]): number {
+  return items.reduce((total, item) => total + item.total, 0);
+}
+
+function normaliseCart(cart: MedusaCart): NormalisedCart {
+  const currencyCode = cart.region?.currency_code ?? DEFAULT_CURRENCY;
+  const items = (cart.items ?? []).map((item) =>
+    mapLineItem(item, currencyCode)
+  );
+
+  const subtotal = cart.subtotal
+    ? normaliseAmount(cart.subtotal)
+    : calculateItemsTotal(items);
+  const total = cart.total
+    ? normaliseAmount(cart.total)
+    : calculateItemsTotal(items);
+
+  return {
+    id: cart.id,
+    items,
+    currencyCode,
+    subtotal,
+    total,
+  };
+}
+
+function normaliseOrder(order: MedusaOrder): OrderSummary {
+  const currencyCode = order.currency_code ?? DEFAULT_CURRENCY;
+  const items = (order.items ?? []).map((item) =>
+    mapLineItem(item, currencyCode)
+  );
+  const subtotal = order.subtotal
+    ? normaliseAmount(order.subtotal)
+    : calculateItemsTotal(items);
+  const total = order.total
+    ? normaliseAmount(order.total)
+    : calculateItemsTotal(items);
+
+  const trackingLinks = (order.fulfillments ?? [])
+    .flatMap((fulfillment) => fulfillment.tracking_links ?? [])
+    .filter((link) => Boolean(link?.url))
+    .map((link) => ({
+      url: link.url as string,
+      trackingNumber: link.tracking_number ?? null,
+    }));
+
+  return {
+    id: order.id,
+    displayId: order.display_id,
+    status: order.status,
+    paymentStatus: order.payment_status,
+    fulfillmentStatus: order.fulfillment_status,
+    createdAt: order.created_at,
+    currencyCode,
+    subtotal,
+    total,
+    items,
+    trackingLinks,
+  };
+}
+
 export const CartProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [items, setItems] = useState<CartItem[]>([]);
+  const [cart, setCart] = useState<NormalisedCart | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isProcessingCheckout, setIsProcessingCheckout] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastOrder, setLastOrder] = useState<OrderSummary | null>(null);
 
-  const addToCart = useCallback((product: Product) => {
-    setItems((prevItems) => {
-      const existingItem = prevItems.find(
-        (item) => item.product.id === product.id
-      );
-      if (existingItem) {
-        return prevItems.map((item) =>
-          item.product.id === product.id
-            ? { ...item, quantity: item.quantity + 1 }
-            : item
+  const loadExistingCart = useCallback(async () => {
+    const storedId = loadStoredCartId();
+    if (!storedId) {
+      setCart(null);
+      return null;
+    }
+
+    const existingCart = await retrieveMedusaCart(storedId);
+    if (!existingCart) {
+      storeCartId(null);
+      setCart(null);
+      return null;
+    }
+
+    const normalised = normaliseCart(existingCart);
+    setCart(normalised);
+    storeCartId(normalised.id);
+    return normalised;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const existing = await loadExistingCart();
+        if (cancelled) {
+          return;
+        }
+        if (existing) {
+          setCart(existing);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadExistingCart]);
+
+  const ensureCart = useCallback(async (): Promise<NormalisedCart> => {
+    setError(null);
+
+    if (cart) {
+      return cart;
+    }
+
+    const existing = await loadExistingCart();
+    if (existing) {
+      return existing;
+    }
+
+    const created = await createMedusaCart();
+    if (!created) {
+      throw new Error('Unable to create a shopping cart. Please try again.');
+    }
+
+    const normalised = normaliseCart(created);
+    storeCartId(normalised.id);
+    setCart(normalised);
+    return normalised;
+  }, [cart, loadExistingCart]);
+
+  const addToCart = useCallback(
+    async (product: Product, quantity = 1) => {
+      if (!product?.plans?.length) {
+        setError('This product is currently unavailable.');
+        return;
+      }
+
+      setIsUpdating(true);
+      setLastOrder(null);
+
+      try {
+        const currentCart = await ensureCart();
+        const variantId = product.plans?.[0]?.id;
+
+        if (!variantId) {
+          throw new Error('Missing product variant.');
+        }
+
+        const updatedCart = await addMedusaLineItem(currentCart.id, {
+          variant_id: variantId,
+          quantity,
+        });
+
+        if (!updatedCart) {
+          throw new Error('Unable to add the product to the cart.');
+        }
+
+        const normalised = normaliseCart(updatedCart);
+        storeCartId(normalised.id);
+        setCart(normalised);
+      } catch (err) {
+        console.error(err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Unable to add the product to the cart.'
+        );
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [ensureCart]
+  );
+
+  const removeFromCart = useCallback(
+    async (lineItemId: string) => {
+      if (!cart) {
+        return;
+      }
+
+      setIsUpdating(true);
+      setError(null);
+
+      try {
+        const updatedCart = await deleteMedusaLineItem(cart.id, lineItemId);
+
+        if (!updatedCart) {
+          throw new Error('Unable to remove the item.');
+        }
+
+        const normalised = normaliseCart(updatedCart);
+        setCart(normalised);
+        if (!normalised.items.length) {
+          storeCartId(normalised.id);
+        }
+      } catch (err) {
+        console.error(err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Unable to remove the item from the cart.'
+        );
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [cart]
+  );
+
+  const updateQuantity = useCallback(
+    async (lineItemId: string, quantity: number) => {
+      if (!lineItemId || quantity < 0) {
+        return;
+      }
+
+      if (quantity === 0) {
+        await removeFromCart(lineItemId);
+        return;
+      }
+
+      if (!cart) {
+        return;
+      }
+
+      setIsUpdating(true);
+      setError(null);
+
+      try {
+        const updatedCart = await updateMedusaLineItem(cart.id, lineItemId, {
+          quantity,
+        });
+
+        if (!updatedCart) {
+          throw new Error('Unable to update the quantity.');
+        }
+
+        const normalised = normaliseCart(updatedCart);
+        setCart(normalised);
+      } catch (err) {
+        console.error(err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Unable to update the quantity.'
+        );
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [cart, removeFromCart]
+  );
+
+  const clearCart = useCallback(async () => {
+    setCart(null);
+    setLastOrder(null);
+    storeCartId(null);
+  }, []);
+
+  const checkout = useCallback(async () => {
+    setError(null);
+
+    const activeCart = cart ?? (await loadExistingCart());
+
+    if (!activeCart || !activeCart.items.length) {
+      setError('Your cart is currently empty.');
+      return null;
+    }
+
+    setIsProcessingCheckout(true);
+
+    try {
+      const order = await completeMedusaCart(activeCart.id);
+
+      if (!order) {
+        throw new Error(
+          'We could not finalise your order. Please try again in a moment.'
         );
       }
-      return [...prevItems, { product, quantity: 1 }];
-    });
-  }, []);
 
-  const removeFromCart = useCallback((productId: string) => {
-    setItems((prevItems) =>
-      prevItems.filter((item) => item.product.id !== productId)
-    );
-  }, []);
+      const normalisedOrder = normaliseOrder(order);
+      setLastOrder(normalisedOrder);
+      await clearCart();
+      return normalisedOrder;
+    } catch (err) {
+      console.error(err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'We could not finalise your order. Please try again in a moment.'
+      );
+      return null;
+    } finally {
+      setIsProcessingCheckout(false);
+    }
+  }, [cart, clearCart, loadExistingCart]);
 
-  const clearCart = useCallback(() => {
-    setItems([]);
-  }, []);
-
-  const updateQuantity = useCallback((product: Product, quantity: number) => {
-    setItems((prevItems) =>
-      prevItems.map((item) =>
-        item.product.id === product.id ? { ...item, quantity } : item
-      )
-    );
-  }, []);
-
-  const getCartTotal = useCallback(() => {
-    return items.reduce(
-      (total, item) => total + item.product.price * item.quantity,
-      0
-    );
-  }, [items]);
-
-  return (
-    <CartContext.Provider
-      value={{
-        items,
-        addToCart,
-        removeFromCart,
-        clearCart,
-        getCartTotal,
-        updateQuantity,
-      }}
-    >
-      {children}
-    </CartContext.Provider>
+  const value = useMemo<CartContextType>(
+    () => ({
+      cartId: cart?.id ?? null,
+      items: cart?.items ?? [],
+      currencyCode: cart?.currencyCode ?? DEFAULT_CURRENCY,
+      subtotal: cart?.subtotal ?? 0,
+      total: cart?.total ?? 0,
+      isLoading,
+      isUpdating,
+      isProcessingCheckout,
+      error,
+      lastOrder,
+      addToCart,
+      updateQuantity,
+      removeFromCart,
+      clearCart,
+      checkout,
+    }),
+    [
+      cart,
+      isLoading,
+      isUpdating,
+      isProcessingCheckout,
+      error,
+      lastOrder,
+      addToCart,
+      updateQuantity,
+      removeFromCart,
+      clearCart,
+      checkout,
+    ]
   );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
 };
 
 export const useCart = (): CartContextType => {

--- a/apps/next/lib/medusa/cart.ts
+++ b/apps/next/lib/medusa/cart.ts
@@ -1,0 +1,244 @@
+import { getMedusaBaseUrl } from './config';
+
+const CART_STORAGE_KEY = 'medusa_cart_id';
+const CART_EXPAND = [
+  'items',
+  'items.variant',
+  'items.variant.product',
+  'region',
+  'shipping_address',
+  'billing_address',
+].join(',');
+
+export const CART_QUERY = `?expand=${encodeURIComponent(CART_EXPAND)}`;
+
+export interface MedusaPrice {
+  amount: number;
+  currency_code: string;
+}
+
+export interface MedusaRegion {
+  id: string;
+  currency_code: string;
+}
+
+export interface MedusaVariant {
+  id: string;
+  title: string;
+  product_id?: string;
+  prices?: MedusaPrice[];
+}
+
+export interface MedusaLineItem {
+  id: string;
+  title: string;
+  description?: string | null;
+  thumbnail?: string | null;
+  quantity: number;
+  variant_id: string;
+  product_id: string;
+  unit_price: number;
+  subtotal?: number;
+  total?: number;
+}
+
+export interface MedusaCart {
+  id: string;
+  items: MedusaLineItem[];
+  region?: MedusaRegion;
+  subtotal?: number;
+  total?: number;
+  tax_total?: number;
+  discount_total?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface MedusaTrackingLink {
+  id?: string;
+  url?: string | null;
+  tracking_number?: string | null;
+}
+
+export interface MedusaFulfillment {
+  id: string;
+  tracking_links?: MedusaTrackingLink[];
+}
+
+export interface MedusaOrder {
+  id: string;
+  display_id?: number;
+  status?: string;
+  payment_status?: string;
+  fulfillment_status?: string;
+  currency_code?: string;
+  subtotal?: number;
+  total?: number;
+  created_at?: string;
+  items?: MedusaLineItem[];
+  fulfillments?: MedusaFulfillment[];
+}
+
+interface CartResponse {
+  cart: MedusaCart;
+}
+
+interface CompleteCartResponse {
+  type: 'order' | 'cart';
+  data: MedusaOrder | MedusaCart;
+  order?: MedusaOrder;
+  cart?: MedusaCart;
+}
+
+async function medusaStoreFetch<T>(
+  path: string,
+  init: RequestInit = {}
+): Promise<T | null> {
+  const baseUrl = getMedusaBaseUrl();
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+
+  const headers = new Headers(init.headers ?? {});
+  headers.set('accept', 'application/json');
+  if (init.body && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      headers,
+      credentials: 'include',
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to fetch Medusa store data from ${url}: ${response.status}`
+      );
+      return null;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    console.error('Failed to fetch Medusa store data', error);
+    return null;
+  }
+}
+
+export async function createMedusaCart(): Promise<MedusaCart | null> {
+  const data = await medusaStoreFetch<CartResponse>(
+    `/store/carts${CART_QUERY}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }
+  );
+
+  return data?.cart ?? null;
+}
+
+export async function retrieveMedusaCart(
+  cartId: string
+): Promise<MedusaCart | null> {
+  const data = await medusaStoreFetch<CartResponse>(
+    `/store/carts/${cartId}${CART_QUERY}`
+  );
+
+  return data?.cart ?? null;
+}
+
+export async function addMedusaLineItem(
+  cartId: string,
+  payload: { variant_id: string; quantity: number }
+): Promise<MedusaCart | null> {
+  const data = await medusaStoreFetch<CartResponse>(
+    `/store/carts/${cartId}/line-items${CART_QUERY}`,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }
+  );
+
+  return data?.cart ?? null;
+}
+
+export async function updateMedusaLineItem(
+  cartId: string,
+  lineId: string,
+  payload: { quantity: number }
+): Promise<MedusaCart | null> {
+  const data = await medusaStoreFetch<CartResponse>(
+    `/store/carts/${cartId}/line-items/${lineId}${CART_QUERY}`,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }
+  );
+
+  return data?.cart ?? null;
+}
+
+export async function deleteMedusaLineItem(
+  cartId: string,
+  lineId: string
+): Promise<MedusaCart | null> {
+  const data = await medusaStoreFetch<CartResponse>(
+    `/store/carts/${cartId}/line-items/${lineId}${CART_QUERY}`,
+    {
+      method: 'DELETE',
+    }
+  );
+
+  return data?.cart ?? null;
+}
+
+export async function completeMedusaCart(
+  cartId: string
+): Promise<MedusaOrder | null> {
+  const data = await medusaStoreFetch<CompleteCartResponse>(
+    `/store/carts/${cartId}/complete`,
+    {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!data) {
+    return null;
+  }
+
+  if (data.type === 'order') {
+    if ('order' in data && data.order) {
+      return data.order;
+    }
+    if (data.data && (data.data as MedusaOrder).id) {
+      return data.data as MedusaOrder;
+    }
+  }
+
+  if (data.order) {
+    return data.order;
+  }
+
+  return null;
+}
+
+export function storeCartId(cartId: string | null) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (cartId) {
+    window.localStorage.setItem(CART_STORAGE_KEY, cartId);
+  } else {
+    window.localStorage.removeItem(CART_STORAGE_KEY);
+  }
+}
+
+export function loadStoredCartId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage.getItem(CART_STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- rebuild the cart context to persist Medusa cart state, perform line item mutations, and complete checkout flows
- add Medusa cart utility functions and update the cart modal to surface totals, checkout, and order confirmation details
- allow modal triggers to be disabled while cart actions are running

## Testing
- npm run lint *(fails: Next CLI not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6640146608323b14b200821bb0748